### PR TITLE
양희철 - modal: confirm, alert용 모달 구현

### DIFF
--- a/src/components/main/Header.tsx
+++ b/src/components/main/Header.tsx
@@ -1,52 +1,30 @@
 "use client";
 
 import Link from "next/link";
-import React, { useEffect, useState } from "react";
-import SignInOutButton from "@/components/main/SignInOutButton";
+import { useEffect, useState } from "react";
+
 import { supabase } from "@/libs/supabase/client";
-import Modal from "../CustomModal";
-import useModalStore from "@/store/store";
+
+import MessageModal from "../modal/MessageModal";
+import SignInOutButton from "@/components/main/SignInOutButton";
 
 const Header = () => {
   const [isSignIn, setIsSignIn] = useState<boolean>(false);
-  const { isModalOpen, toggleModal, setModalData, setBtnData } =
-    useModalStore();
+  const [toggleModal, setToggleModal] = useState(false);
+  const [modalData, setModalData] = useState({});
 
-  console.log(isModalOpen);
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
   const onClickLogout = () => {
-    toggleModal();
-    setModalData(
-      <div className="px-10 py-2">
-        <h2 className="text-2xl font-bold text-center mb-1">로그아웃</h2>
-        <p className="text-center text-lg">로그아웃 하시겠습니까?</p>
-      </div>
-    );
-    setBtnData(
-      <div className="flex gap-2 mt-2">
-        <button
-          className="btn btn-primary px-8 tracking-widest duration-200 h-10 min-h-6"
-          onClick={async () => {
-            await supabase.auth.signOut();
-            setModalData(
-              <p className="text-center text-lg">로그아웃 되었습니다.</p>
-            );
-            setBtnData(
-              <button className="text-primary" onClick={toggleModal}>
-                확인
-              </button>
-            );
-          }}
-        >
-          확인
-        </button>
-        <button
-          className="btn btn-neutral text-black px-8 tracking-widest duration-200 h-10 min-h-6"
-          onClick={toggleModal}
-        >
-          취소
-        </button>
-      </div>
-    );
+    setToggleModal(true);
+    setModalData({
+      type: "confirm",
+      name: "로그아웃",
+      text: "로그아웃 하시겠습니까?",
+      func: signOut,
+    });
   };
 
   useEffect(() => {
@@ -54,6 +32,19 @@ const Header = () => {
     const { data: authListener } = supabase.auth.onAuthStateChange(
       (event, session) => {
         setIsSignIn(!!session?.user);
+        if (event === "SIGNED_IN") {
+          setToggleModal(true);
+          setModalData({
+            type: "alert",
+            text: "로그인 되었습니다.",
+          });
+        } else if (event === "SIGNED_OUT") {
+          setToggleModal(true);
+          setModalData({
+            type: "alert",
+            text: "로그아웃 되었습니다.",
+          });
+        }
       }
     );
 
@@ -200,7 +191,9 @@ const Header = () => {
           )}
         </div>
       </div>
-      {isModalOpen && <Modal />}
+      {toggleModal && (
+        <MessageModal modalToggle={setToggleModal} {...modalData} />
+      )}
     </>
   );
 };

--- a/src/components/modal/CustomModal.tsx
+++ b/src/components/modal/CustomModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import useModalStore from "@/store/store";
-import { Meteors } from "./ui/meteors";
+import { Meteors } from "../ui/meteors";
 const Modal = () => {
   const { modalData, BtnData } = useModalStore();
 

--- a/src/components/modal/MessageModal.tsx
+++ b/src/components/modal/MessageModal.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+
+type ModalProp = {
+  modalToggle: React.Dispatch<React.SetStateAction<boolean>>;
+  type?: "alert" | "confirm";
+  name?: string;
+  text?: string;
+  func?: () => void;
+};
+
+const MessageModal = ({ type, name, text, func, modalToggle }: ModalProp) => {
+  return (
+    <dialog id="my_modal_2" className={"modal modal-open"}>
+      <div className="modal-box text-black max-w-md w-fit flex flex-col gap-2">
+        <div className="px-10 py-2">
+          <h2 className="text-2xl font-bold text-center mb-1">{name}</h2>
+          <p className="text-center text-lg">{text}</p>
+          <div className="modal-action flex justify-center items-center mt-0">
+            <form method="dialog">
+              {type === "confirm" ? (
+                <div className="flex gap-2 mt-2">
+                  <button
+                    className="btn btn-primary px-8 tracking-widest duration-200 h-10 min-h-6"
+                    onClick={func}
+                  >
+                    확인
+                  </button>
+                  <button
+                    className="btn btn-neutral text-black px-8 tracking-widest duration-200 h-10 min-h-6"
+                    onClick={() => modalToggle(false)}
+                  >
+                    취소
+                  </button>
+                </div>
+              ) : (
+                <button
+                  className="text-primary"
+                  onClick={() => modalToggle(false)}
+                >
+                  확인
+                </button>
+              )}
+            </form>
+          </div>
+        </div>
+      </div>
+    </dialog>
+  );
+};
+
+export default MessageModal;

--- a/src/components/modal/MessageModal.tsx
+++ b/src/components/modal/MessageModal.tsx
@@ -17,29 +17,31 @@ const MessageModal = ({ type, name, text, func, modalToggle }: ModalProp) => {
           <p className="text-center text-lg">{text}</p>
           <div className="modal-action flex justify-center items-center mt-0">
             <form method="dialog">
-              {type === "confirm" ? (
-                <div className="flex gap-2 mt-2">
+              <div className="flex gap-2 mt-2">
+                {type === "confirm" ? (
+                  <>
+                    <button
+                      className="btn btn-primary px-8 tracking-widest duration-200 h-10 min-h-6"
+                      onClick={func}
+                    >
+                      확인
+                    </button>
+                    <button
+                      className="btn btn-neutral text-black px-8 tracking-widest duration-200 h-10 min-h-6"
+                      onClick={() => modalToggle(false)}
+                    >
+                      취소
+                    </button>
+                  </>
+                ) : (
                   <button
-                    className="btn btn-primary px-8 tracking-widest duration-200 h-10 min-h-6"
-                    onClick={func}
+                    className="text-primary"
+                    onClick={() => modalToggle(false)}
                   >
                     확인
                   </button>
-                  <button
-                    className="btn btn-neutral text-black px-8 tracking-widest duration-200 h-10 min-h-6"
-                    onClick={() => modalToggle(false)}
-                  >
-                    취소
-                  </button>
-                </div>
-              ) : (
-                <button
-                  className="text-primary"
-                  onClick={() => modalToggle(false)}
-                >
-                  확인
-                </button>
-              )}
+                )}
+              </div>
             </form>
           </div>
         </div>

--- a/src/components/starsign/StarSignContainer.tsx
+++ b/src/components/starsign/StarSignContainer.tsx
@@ -14,7 +14,7 @@ import {
   Aries,
   Virgo,
 } from "./StarSigns";
-import Modal from "@/components/CustomModal";
+import Modal from "@/components/modal/CustomModal";
 import useModalStore from "@/store/store";
 const StarSignForm = () => {
   const { isModalOpen } = useModalStore();


### PR DESCRIPTION
## 요약

- confrim과 alert용 커스텀 모달 필요로 커스텀 모달 구현
-  MessageModal 컴포넌트 사용법
    >  <img width="571" alt="스크린샷 2024-03-23 오후 11 53 26" src="https://github.com/React4-HOT6/starry-night/assets/100992153/5c733aba-ea68-4915-8e76-0165590b35d1"> toggleModal:모달 open toggle 
modalData: MessageModal 에 넣어줄 prop 데이터
 type -> 'confirm' 'alert'으로 구성
 name -> 모달 제목
 text -> 모달 내용
 func -> type 이 'confirm'일때 확인 버튼을 눌렀을때 실행할 함수
예시: <img width="324" alt="스크린샷 2024-03-24 오전 12 00 02" src="https://github.com/React4-HOT6/starry-night/assets/100992153/5cb2e547-5062-4879-ade4-f6b96ab01bdc"> <img width="657" alt="스크린샷 2024-03-23 오후 11 52 14" src="https://github.com/React4-HOT6/starry-night/assets/100992153/5a04030c-6e65-4f19-ac21-b0b714bc5075">


## 변경점

- 기존 커스텀 모달과 새로운 모달 파일을 관리할 폴더 생성
## 스크린샷
<img width="1334" alt="스크린샷 2024-03-23 오후 11 33 43" src="https://github.com/React4-HOT6/starry-night/assets/100992153/c77da4aa-30af-4d8b-9d11-5927be6930e6">

